### PR TITLE
import npm package directly from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.17.11",
     "lowdb": "^1.0.0",
     "nanoid": "^2.1.11",
-    "oidc-provider": "^6.23.1",
+    "oidc-provider": "github:5r1n1/node-oidc-provider",
     "sequelize": "^5.21.4",
     "sqlite3": "^4.1.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const path = require('path');
 const express = require('express'); // eslint-disable-line import/no-unresolved
 const helmet = require('helmet');
 
-const { Provider } = require('../../node-oidc-provider/lib');
+const { Provider } = require('oidc-provider');
 
 const adapter = require('./adapters/sequelize');
 const Account = require('./support/account');


### PR DESCRIPTION
the OpenID Connect ( OIDC ) provider
was customized by @5r1n1 to include
a custom Resource Owner Password Credential ( ROPC )
grant flow ( https://github.com/5r1n1/node-oidc-provider/commit/46820b5ff9113d31243e50c94eaaca9aa3e8d4f7 ).
This changeset imports the custom package
directly from github rather than having to
clone a copy of the package to a specific
hardcoded location in the filesystem
( ../../node-oidc-provider ) to run this app

Signed-off-by: shine <shine@m5nv.com>